### PR TITLE
[feat] #4 메인 페이지 인기순 섹션 추가 및 GA 조회수 이벤트

### DIFF
--- a/src/app/api/result/[id]/view/route.ts
+++ b/src/app/api/result/[id]/view/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+  if (!apiUrl?.startsWith("http")) {
+    return new NextResponse(null, { status: 503 });
+  }
+
+  try {
+    await fetch(`${apiUrl}/results/${id}/view`, { method: "POST" });
+  } catch {
+    // fire-and-forget
+  }
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/app/api/results/popular/route.ts
+++ b/src/app/api/results/popular/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+  if (!apiUrl?.startsWith("http")) {
+    return NextResponse.json({ detail: "API URL이 설정되지 않았습니다." }, { status: 503 });
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10_000);
+
+  try {
+    const upstream = await fetch(`${apiUrl}/results/popular`, { signal: controller.signal });
+    clearTimeout(timeoutId);
+
+    if (!upstream.ok) {
+      const error = await upstream.json().catch(() => ({ detail: upstream.statusText }));
+      return NextResponse.json(error, { status: upstream.status });
+    }
+
+    const data = await upstream.json();
+
+    return NextResponse.json({
+      items: (data.items ?? []).map((item: Record<string, unknown>) => ({
+        id: item.id,
+        videoUrl: item.video_url,
+        title: item.title ?? null,
+        channelName: item.channel_name ?? null,
+        thumbnailUrl: item.thumbnail_url ?? null,
+        createdAt: item.created_at,
+      })),
+      total: data.total ?? 0,
+    });
+  } catch (err) {
+    clearTimeout(timeoutId);
+    if (err instanceof Error && err.name === "AbortError") {
+      return NextResponse.json({ detail: "request timeout" }, { status: 504 });
+    }
+    return NextResponse.json({ detail: "failed to fetch popular results" }, { status: 500 });
+  }
+}

--- a/src/app/result/[id]/page.tsx
+++ b/src/app/result/[id]/page.tsx
@@ -2,6 +2,7 @@ import { cache } from "react";
 import { headers } from "next/headers";
 import { ResultPage } from "@/views/result";
 import { getResultById } from "@/entities/result";
+import { ViewTracker } from "@/features/track-view";
 import type { ChordResult } from "@/shared/model";
 import { notFound } from "next/navigation";
 
@@ -27,7 +28,12 @@ export default async function ResultRoute({ params }: Props) {
 
   if (!result) notFound();
 
-  return <ResultPage result={result} />;
+  return (
+    <>
+      <ViewTracker id={id} title={result.title} />
+      <ResultPage result={result} />
+    </>
+  );
 }
 
 export async function generateMetadata({ params }: Props) {

--- a/src/entities/result/api/getPopularResults.ts
+++ b/src/entities/result/api/getPopularResults.ts
@@ -1,0 +1,7 @@
+import type { ResultListResponse } from "../model/types";
+
+export async function getPopularResults(): Promise<ResultListResponse> {
+  const res = await fetch("/api/results/popular");
+  if (!res.ok) return { items: [], total: 0 };
+  return res.json() as Promise<ResultListResponse>;
+}

--- a/src/entities/result/api/incrementResultView.ts
+++ b/src/entities/result/api/incrementResultView.ts
@@ -1,0 +1,3 @@
+export async function incrementResultView(id: string): Promise<void> {
+  await fetch(`/api/result/${id}/view`, { method: "POST" }).catch(() => {});
+}

--- a/src/entities/result/index.ts
+++ b/src/entities/result/index.ts
@@ -2,4 +2,6 @@ export type { ResultListItem, ResultListResponse } from "./model/types";
 export { resultsQueryKey } from "./model/queryKeys";
 export { getResults } from "./api/getResults";
 export { getResultById } from "./api/getResultById";
+export { getPopularResults } from "./api/getPopularResults";
+export { incrementResultView } from "./api/incrementResultView";
 export { ResultListItemCard } from "./ui/ResultListItemCard";

--- a/src/features/list-results/api/usePopularResults.ts
+++ b/src/features/list-results/api/usePopularResults.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { getPopularResults } from "@/entities/result";
+import type { ResultListResponse } from "@/entities/result";
+
+export const popularResultsQueryKey = ["results", "popular"] as const;
+
+export function usePopularResults() {
+  return useQuery<ResultListResponse>({
+    queryKey: popularResultsQueryKey,
+    queryFn: getPopularResults,
+    refetchOnMount: "always",
+  });
+}

--- a/src/features/list-results/index.ts
+++ b/src/features/list-results/index.ts
@@ -1,2 +1,4 @@
 export { ResultList } from "./ui/ResultList";
+export { PopularList } from "./ui/PopularList";
 export { useResults, resultsQueryKey } from "./api/useResults";
+export { usePopularResults, popularResultsQueryKey } from "./api/usePopularResults";

--- a/src/features/list-results/ui/PopularList.tsx
+++ b/src/features/list-results/ui/PopularList.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { usePopularResults } from "../api/usePopularResults";
+import { ResultListItemCard } from "@/entities/result";
+
+export function PopularList() {
+  const { data, isPending, isError } = usePopularResults();
+
+  if (isPending) {
+    return (
+      <div className="flex flex-col gap-2">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="h-20 animate-pulse rounded-xl bg-bg-card/40" />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError || !data || data.items.length === 0) return null;
+
+  return (
+    <div className="grid grid-cols-3 gap-2">
+      {data.items.map((item) => (
+        <ResultListItemCard key={item.id} item={item} />
+      ))}
+    </div>
+  );
+}

--- a/src/features/track-view/index.ts
+++ b/src/features/track-view/index.ts
@@ -1,0 +1,1 @@
+export { ViewTracker } from "./ui/ViewTracker";

--- a/src/features/track-view/ui/ViewTracker.tsx
+++ b/src/features/track-view/ui/ViewTracker.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useEffect } from "react";
+import { sendGAEvent } from "@next/third-parties/google";
+import { incrementResultView } from "@/entities/result";
+
+interface Props {
+  id: string;
+  title: string;
+}
+
+export function ViewTracker({ id, title }: Props) {
+  useEffect(() => {
+    if (process.env.NODE_ENV === "production") {
+      sendGAEvent("event", "result_view", { result_id: id, title });
+    }
+    void incrementResultView(id);
+  }, [id, title]);
+
+  return null;
+}

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback } from "react";
 import { useExtractChord, UrlInputForm, LoadingState } from "@/features/extract-chord";
-import { ResultList } from "@/features/list-results";
+import { PopularList, ResultList } from "@/features/list-results";
 
 export function HomePage() {
   const mutation = useExtractChord();
@@ -67,7 +67,17 @@ export function HomePage() {
         </section>
       )}
 
+      <section className="mx-auto max-w-7xl px-8 pb-8">
+        <p className="font-mono text-xs tracking-widest text-text-secondary uppercase mb-4">
+          Popular
+        </p>
+        <PopularList />
+      </section>
+
       <section className="mx-auto max-w-7xl px-8 pb-16">
+        <p className="font-mono text-xs tracking-widest text-text-secondary uppercase mb-4">
+          Recent
+        </p>
         <ResultList />
       </section>
     </main>


### PR DESCRIPTION
## Summary

- 결과 페이지 방문 시 GA `result_view` 이벤트 전송 (production 환경에서만)
- 결과 페이지 방문 시 `view_count` 증가 API 호출
- 메인 페이지에 **Popular** / **Recent** 섹션 분리 추가

## Changes

- `features/track-view` — `ViewTracker` 클라이언트 컴포넌트 신규
- `app/api/result/[id]/view` — 조회수 증가 프록시 라우트 신규
- `app/api/results/popular` — 인기순 목록 프록시 라우트 신규
- `entities/result` — `getPopularResults`, `incrementResultView` API 함수 추가
- `features/list-results` — `PopularList` 컴포넌트, `usePopularResults` 훅 추가
- `views/home` — Popular / Recent 섹션 렌더링

## Test plan

- [x] 결과 페이지 방문 후 DB `view_count` 증가 확인
- [x] GA 이벤트는 production 환경에서만 전송됨 확인
- [x] 메인 페이지에 Popular 섹션 표시 확인 (view_count > 0인 항목이 있을 때)

closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)