### PR TITLE
feat: #8 다크/라이트 테마 토글 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ pnpm-debug.log*
 .claude/settings.local.json
 _workspace/
 _workspace_prev_*/
+.playwright-mcp/
 
 # debug
 npm-debug.log*

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,15 +1,16 @@
 @import "tailwindcss";
 
+/* ── Semantic tokens (Tailwind v4: indirect via CSS vars) ── */
 @theme inline {
-  --color-bg-base: #111319;
-  --color-bg-nav: #1c1f26;
-  --color-bg-card: #191b22;
-  --color-bg-card-mobile: #1e1f26;
-  --color-bg-input: #282a30;
-  --color-bg-dark: #0c0e14;
+  --color-bg-base: var(--bg-base);
+  --color-bg-nav: var(--bg-nav);
+  --color-bg-card: var(--bg-card);
+  --color-bg-card-mobile: var(--bg-card-mobile);
+  --color-bg-input: var(--bg-input);
+  --color-bg-dark: var(--bg-dark);
 
-  --color-text-primary: #e2e2eb;
-  --color-text-secondary: #c3c6d7;
+  --color-text-primary: var(--text-primary);
+  --color-text-secondary: var(--text-secondary);
 
   --color-accent-light: #b4c5ff;
   --color-accent: #618bff;
@@ -17,7 +18,7 @@
   --color-accent-deep: #002a78;
 
   --color-orange: #ffb784;
-  --color-border: #434654;
+  --color-border: var(--border);
 
   --font-sans: var(--font-inter);
   --font-heading: var(--font-space-grotesk);
@@ -25,13 +26,39 @@
   --font-noto: var(--font-noto-sans-kr);
 }
 
+/* ── Light mode ── */
+:root {
+  --bg-base: #f5f7fb;
+  --bg-nav: #ffffff;
+  --bg-card: #eef0f8;
+  --bg-card-mobile: #f0f2f9;
+  --bg-input: #e4e7f2;
+  --bg-dark: #d8dbe8;
+  --text-primary: #1a1d2e;
+  --text-secondary: #4a4f6a;
+  --border: #c8cce0;
+}
+
+/* ── Dark mode ── */
+.dark {
+  --bg-base: #111319;
+  --bg-nav: #1c1f26;
+  --bg-card: #191b22;
+  --bg-card-mobile: #1e1f26;
+  --bg-input: #282a30;
+  --bg-dark: #0c0e14;
+  --text-primary: #e2e2eb;
+  --text-secondary: #c3c6d7;
+  --border: #434654;
+}
+
 * {
   box-sizing: border-box;
 }
 
 body {
-  background-color: #111319;
-  color: #e2e2eb;
+  background-color: var(--bg-base);
+  color: var(--text-primary);
   font-family: var(--font-inter), Inter, sans-serif;
   -webkit-font-smoothing: antialiased;
 }
@@ -42,10 +69,10 @@ body {
   width: 4px;
 }
 ::-webkit-scrollbar-track {
-  background: #191b22;
+  background: var(--bg-card);
 }
 ::-webkit-scrollbar-thumb {
-  background: #434654;
+  background: var(--border);
   border-radius: 9999px;
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,7 +35,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   return (
     <html
       lang={locale}
-      style={{ colorScheme: "dark" }}
+      suppressHydrationWarning
       className={[
         inter.variable,
         spaceGrotesk.variable,

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ThemeProvider } from "next-themes";
 import { useState } from "react";
 
 export function Providers({ children }: { children: React.ReactNode }) {
@@ -17,5 +18,9 @@ export function Providers({ children }: { children: React.ReactNode }) {
       }),
   );
 
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  return (
+    <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </ThemeProvider>
+  );
 }

--- a/src/shared/ui/Header.tsx
+++ b/src/shared/ui/Header.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { LanguageToggle } from "./LanguageToggle";
+import { ThemeToggle } from "./ThemeToggle";
 
 export function Header() {
   return (
@@ -19,6 +20,7 @@ export function Header() {
 
         {/* Right */}
         <div className="ml-auto flex items-center gap-4">
+          <ThemeToggle />
           <LanguageToggle />
         </div>
       </nav>

--- a/src/shared/ui/ThemeToggle.tsx
+++ b/src/shared/ui/ThemeToggle.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+
+export function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  // next-themes 하이드레이션 불일치 방지용 mounted guard
+  // eslint-disable-next-line react-hooks/set-state-in-effect
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) {
+    return <div className="h-8 w-8" />;
+  }
+
+  const isDark = resolvedTheme === "dark";
+
+  return (
+    <button
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      className="flex h-8 w-8 items-center justify-center rounded-md text-text-secondary transition-colors hover:bg-bg-input hover:text-text-primary"
+      aria-label={isDark ? "라이트 모드로 전환" : "다크 모드로 전환"}
+    >
+      {isDark ? <SunIcon /> : <MoonIcon />}
+    </button>
+  );
+}
+
+function SunIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+    </svg>
+  );
+}


### PR DESCRIPTION
closes #8

## 변경 내용

다크/라이트 테마 전환 기능 추가. next-themes + Tailwind v4 CSS 변수 방식으로 구현.

## 작업 내용

- [x] `ThemeToggle` 클라이언트 컴포넌트 생성 (sun/moon SVG 아이콘)
- [x] `globals.css` `@theme inline` → CSS 변수 간접 참조 변경, `:root`/`.dark` 팔레트 추가
- [x] `providers.tsx` `ThemeProvider` 래핑 (`attribute="class"`, `defaultTheme="dark"`, `enableSystem`)
- [x] `layout.tsx` `suppressHydrationWarning` 추가, `colorScheme` 하드코딩 제거
- [x] `Header.tsx` LanguageToggle 오른쪽에 `ThemeToggle` 배치

## 체크리스트

- [x] 타입 오류 없음
- [x] 불필요한 console.log 제거
- [x] 관련 Issue 연결됨

## 참고

- next-themes 하이드레이션 방지용 mounted guard 패턴 사용
- 기본값 다크모드 유지 (`defaultTheme="dark"`)