### PR TITLE
feat: #10 ChordEntry 타입 fret/voicing 추가 및 ChordDiagram 동적 바레 렌더링

### DIFF
--- a/src/entities/chord/ui/ChordDiagram.tsx
+++ b/src/entities/chord/ui/ChordDiagram.tsx
@@ -6,6 +6,8 @@ interface Props {
   chordName: string;
   isActive?: boolean;
   size?: "sm" | "md" | "lg";
+  fret?: number;
+  voicing?: "open" | "barre";
 }
 
 const SIZES = {
@@ -14,7 +16,7 @@ const SIZES = {
   lg: { w: 190, h: 214 },
 };
 
-type ChordEntry = {
+type ChordShape = {
   // [string, fret, finger?]  string 1=high e, 6=low E  /  finger 1=index … 4=pinky
   fingers: [number, number, number?][];
   barres?: { fret: number; fromString: number; toString: number }[];
@@ -22,7 +24,7 @@ type ChordEntry = {
 };
 
 // Finger positions for common chords
-const CHORD_DATA: Record<string, ChordEntry> = {
+const CHORD_DATA: Record<string, ChordShape> = {
   // ── Open chords ──
   Am: {
     fingers: [
@@ -405,7 +407,7 @@ const CHORD_DATA: Record<string, ChordEntry> = {
  * 2. 슬래시 코드 → 루트만 사용 (F/G → F)
  * 3. 확장 코드 → 루트+장단조만 사용 (Cm7b5 → Cm, Cmaj7 → C)
  */
-function resolveChordData(name: string): ChordEntry | null {
+function resolveChordData(name: string): ChordShape | null {
   if (CHORD_DATA[name]) return CHORD_DATA[name];
 
   // 슬래시 코드 처리
@@ -423,7 +425,15 @@ function resolveChordData(name: string): ChordEntry | null {
   return null;
 }
 
-export function ChordDiagram({ chordName, isActive = false, size = "md" }: Props) {
+function buildBarreFallback(fret: number): ChordShape {
+  return {
+    fingers: [],
+    barres: [{ fret: 1, fromString: 1, toString: 6 }],
+    position: fret,
+  };
+}
+
+export function ChordDiagram({ chordName, isActive = false, size = "md", fret, voicing }: Props) {
   const ref = useRef<HTMLDivElement>(null);
   const { w, h } = SIZES[size];
 
@@ -436,7 +446,10 @@ export function ChordDiagram({ chordName, isActive = false, size = "md" }: Props
         if (!ref.current) return;
         ref.current.innerHTML = "";
 
-        const data = resolveChordData(chordName);
+        const staticData = resolveChordData(chordName);
+        const data =
+          staticData ??
+          (voicing === "barre" && fret != null && fret >= 1 ? buildBarreFallback(fret) : null);
         const fingers = data?.fingers ?? [];
         const barres = data?.barres ?? [];
         const position = data?.position ?? 1;
@@ -525,7 +538,7 @@ export function ChordDiagram({ chordName, isActive = false, size = "md" }: Props
     };
 
     drawChord();
-  }, [chordName, isActive, w, h]);
+  }, [chordName, isActive, w, h, fret, voicing]);
 
   return (
     <article

--- a/src/entities/chord/ui/ChordGrid.tsx
+++ b/src/entities/chord/ui/ChordGrid.tsx
@@ -23,7 +23,12 @@ export function ChordGrid({ allChords, activeChordIdx }: Props) {
               <span className="font-mono text-sm text-text-secondary/60 tabular-nums">
                 {prev.time}
               </span>
-              <ChordDiagram chordName={prev.chord} size="sm" />
+              <ChordDiagram
+                chordName={prev.chord}
+                size="sm"
+                fret={prev.fret}
+                voicing={prev.voicing}
+              />
             </>
           ) : (
             <div className="w-[202px] h-[160px]" />
@@ -37,7 +42,13 @@ export function ChordGrid({ allChords, activeChordIdx }: Props) {
               <span className="font-mono text-sm font-bold text-accent-light/70 tabular-nums">
                 {current.time}
               </span>
-              <ChordDiagram chordName={current.chord} isActive size="lg" />
+              <ChordDiagram
+                chordName={current.chord}
+                isActive
+                size="lg"
+                fret={current.fret}
+                voicing={current.voicing}
+              />
             </>
           ) : (
             <div className="w-[190px] h-[240px]" />
@@ -51,7 +62,12 @@ export function ChordGrid({ allChords, activeChordIdx }: Props) {
               <span className="font-mono text-sm text-text-secondary/60 tabular-nums">
                 {next.time}
               </span>
-              <ChordDiagram chordName={next.chord} size="sm" />
+              <ChordDiagram
+                chordName={next.chord}
+                size="sm"
+                fret={next.fret}
+                voicing={next.voicing}
+              />
             </>
           ) : (
             <div className="w-[202px] h-[160px]" />

--- a/src/shared/model/index.ts
+++ b/src/shared/model/index.ts
@@ -1,6 +1,8 @@
 export interface ChordEntry {
-  time: string; // "0:12"
-  chord: string; // "Am"
+  time: string;
+  chord: string;
+  fret: number;
+  voicing: "open" | "barre";
 }
 
 export interface LyricLine {


### PR DESCRIPTION
closes #10

## 변경 사항

- `ChordEntry` 인터페이스에 `fret: number`, `voicing: "open" | "barre"` 필드 추가 (BE Basic Pitch 마이그레이션 대응)
- `ChordDiagram` 내부 `ChordEntry` 타입을 `ChordShape`으로 rename (외부 타입 이름 충돌 해소)
- `ChordDiagram`에 `fret?`, `voicing?` optional props 추가
- `CHORD_DATA`에 없는 코드 + `voicing === "barre"`일 때 `buildBarreFallback(fret)`으로 풀 바레 다이어그램 렌더링
- `ChordGrid`에서 `ChordDiagram` 세 위치(prev/current/next) 모두에 `fret`/`voicing` props 체이닝

## 테스트

- [ ] `pnpm tsc --noEmit` 오류 없음
- [ ] `pnpm lint` 오류 없음
- [ ] `CHORD_DATA` 등록 코드(예: Am, G)는 기존 하드코딩 다이어그램 그대로 표시
- [ ] `CHORD_DATA` 미등록 바레 코드(예: C#m7, Abmaj7 등)에서 백엔드 fret 기반 바레 다이어그램 표시