### PR TITLE
feat: #14 duration(총 재생시간) 필드 추가

### DIFF
--- a/src/app/api/results/popular/route.ts
+++ b/src/app/api/results/popular/route.ts
@@ -29,6 +29,7 @@ export async function GET() {
         title: item.title ?? null,
         channelName: item.channel_name ?? null,
         thumbnailUrl: item.thumbnail_url ?? null,
+        duration: (item.duration as number | null) ?? null,
         createdAt: item.created_at,
       })),
       total: data.total ?? 0,

--- a/src/app/api/results/route.ts
+++ b/src/app/api/results/route.ts
@@ -33,6 +33,7 @@ export async function GET(req: NextRequest) {
         title: item.title ?? null,
         channelName: item.channel_name ?? null,
         thumbnailUrl: item.thumbnail_url ?? null,
+        duration: (item.duration as number | null) ?? null,
         createdAt: item.created_at,
       })),
       total: data.total ?? 0,

--- a/src/entities/result/model/types.ts
+++ b/src/entities/result/model/types.ts
@@ -4,6 +4,7 @@ export interface ResultListItem {
   title: string | null;
   channelName: string | null;
   thumbnailUrl: string | null;
+  duration: number | null;
   createdAt: string;
 }
 

--- a/src/features/list-results/ui/PopularAlbumCard.tsx
+++ b/src/features/list-results/ui/PopularAlbumCard.tsx
@@ -1,12 +1,15 @@
 import Link from "next/link";
 import Image from "next/image";
 import type { ResultListItem } from "@/entities/result";
+import { formatDuration } from "@/shared/lib/formatDuration";
 
 interface PopularAlbumCardProps {
   item: ResultListItem;
 }
 
 export function PopularAlbumCard({ item }: PopularAlbumCardProps) {
+  const formattedDuration = formatDuration(item.duration);
+
   return (
     <Link href={`/result/${item.id}`} className="group flex flex-col gap-2">
       <div className="relative aspect-square w-full overflow-hidden rounded-lg bg-bg-card/60">
@@ -21,6 +24,11 @@ export function PopularAlbumCard({ item }: PopularAlbumCardProps) {
         ) : (
           <div className="h-full w-full bg-bg-base/60" />
         )}
+        {formattedDuration ? (
+          <span className="absolute bottom-1.5 right-1.5 rounded bg-black/70 px-1.5 py-0.5 font-mono text-xs text-white">
+            {formattedDuration}
+          </span>
+        ) : null}
       </div>
       <div className="flex flex-col gap-0.5 px-1">
         <p className="line-clamp-2 font-sans text-sm font-semibold text-text-primary">

--- a/src/shared/lib/formatDuration.ts
+++ b/src/shared/lib/formatDuration.ts
@@ -1,0 +1,11 @@
+export function formatDuration(totalSeconds: number | null | undefined): string | null {
+  if (totalSeconds == null) return null;
+  if (!Number.isFinite(totalSeconds) || totalSeconds <= 0) return null;
+  const s = Math.floor(totalSeconds);
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  const mm = String(m).padStart(2, "0");
+  const ss = String(sec).padStart(2, "0");
+  return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`;
+}


### PR DESCRIPTION
closes #14

## 변경 사항

- `src/shared/lib/formatDuration.ts`: 초 → MM:SS/H:MM:SS 변환 유틸 (null/0/Infinity → null)
- `src/entities/result/model/types.ts`: `ResultListItem`에 `duration: number | null` 추가
- `src/app/api/results/route.ts`, `src/app/api/results/popular/route.ts`: duration 매핑 추가
- `src/features/list-results/ui/PopularAlbumCard.tsx`: 썸네일 우측 하단 duration 뱃지 (null이면 미렌더)

## DB Migration

Supabase Dashboard SQL Editor에서 이미 실행 완료:
```sql
ALTER TABLE chord_results ADD COLUMN IF NOT EXISTS duration INTEGER NULL;
```

## 배포 순서

1. DB migration (완료)
2. BE 배포 (xmun74/chordlens-be#9)
3. FE 배포

## 테스트

- [x] 신규 영상 분석 시 PopularAlbumCard에 재생시간 뱃지 표시
- [x] 기존 영상(duration=null) 카드에 뱃지 미표시
- [ ] 1시간 이상 영상 H:MM:SS 포맷 확인

## 참고

- BE 연동: xmun74/chordlens-be#9
- `cache_get()` duration 미반영은 의도된 범위 제한 (ExtractResponse 연쇄 변경 방지, 후속 task로 처리)