### PR TITLE
feat: 모바일 반응형 UI 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,14 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# OMX runtime state
+.omx/*
+!.omx/context/
+!.omx/context/*.md
+!.omx/interviews/
+!.omx/interviews/*.md
+!.omx/specs/
+!.omx/specs/*.md
+!.omx/plans/
+!.omx/plans/*.md

--- a/.omx/context/mobile-responsive-seo-aeo-20260519T050442Z.md
+++ b/.omx/context/mobile-responsive-seo-aeo-20260519T050442Z.md
@@ -1,0 +1,36 @@
+# Deep Interview Context Snapshot: mobile-responsive-seo-aeo
+
+- Task statement: Implement mobile responsive UI while considering SEO and AEO search optimization.
+- Desired outcome: Not yet clarified. User wants a responsive UI that also improves search/answer-engine visibility.
+- Stated solution: Mobile responsive UI plus SEO/AEO optimization.
+- Probable intent hypothesis: Improve real user usability on mobile and make ChordLens pages more discoverable and answerable by search engines or AI answer surfaces.
+- Known facts/evidence:
+  - Existing brownfield Next.js 16 project using React 19, Tailwind CSS v4, next-intl, React Query, and Feature-Sliced Design style directories.
+  - Main routes found: `src/app/[locale]/page.tsx` and `src/app/[locale]/result/[id]/page.tsx`.
+  - Locale layout has static metadata with title/description/OpenGraph in `src/app/[locale]/layout.tsx`.
+  - Result route has dynamic `generateMetadata`, but description is currently concise: key and tempo only.
+  - Home UI uses `px-8`, large hero text, and `lg:flex-row`; likely needs explicit small-screen refinement.
+  - Result UI stacks major sections with `px-8 py-10`; chord/player/grid components may need mobile-specific audit.
+- Constraints:
+  - No explicit constraints stated yet.
+  - Existing stack should likely be preserved unless user approves otherwise.
+- Unknowns/open questions:
+  - Primary intent: conversion, readability, search traffic, indexing, AEO snippets, or all of these.
+  - Target pages and first-pass scope.
+  - Non-goals.
+  - Decision boundaries for visual changes, metadata/schema changes, and content/copy changes.
+  - Testable acceptance criteria.
+- Decision-boundary unknowns:
+  - Whether OMX may change layout/visual hierarchy without confirming each screen.
+  - Whether OMX may add or alter structured data, canonical URLs, OpenGraph/Twitter metadata, sitemap/robots, and localized metadata.
+  - Whether OMX may change copy for SEO/AEO clarity.
+- Likely codebase touchpoints:
+  - `src/views/home/ui/HomePage.tsx`
+  - `src/views/result/ui/ResultPage.tsx`
+  - `src/entities/chord/ui/*`
+  - `src/entities/video/ui/VideoCard.tsx`
+  - `src/features/list-results/ui/*`
+  - `src/app/[locale]/layout.tsx`
+  - `src/app/[locale]/result/[id]/page.tsx`
+  - `src/app/globals.css`
+- Prompt-safe initial-context summary status: not_needed

--- a/.omx/interviews/mobile-responsive-seo-aeo-20260519T051413Z.md
+++ b/.omx/interviews/mobile-responsive-seo-aeo-20260519T051413Z.md
@@ -1,0 +1,60 @@
+# Deep Interview Transcript: mobile-responsive-seo-aeo
+
+- Profile: standard
+- Context type: brownfield
+- Final ambiguity: 18%
+- Threshold: 20%
+- Context snapshot: `.omx/context/mobile-responsive-seo-aeo-20260519T050442Z.md`
+
+## Summary
+
+The user wants a first-pass responsive UI implementation for the existing ChordLens home and result screens. Mobile usability is the primary goal. SEO/AEO remains important, but implementation should be split into a later PR; this pass should not expand metadata, structured data, sitemap, robots, or content strategy.
+
+The result page is the priority because it is more complex than the home page. The mobile result page should follow the current desktop result page as the reference flow rather than introducing a new information architecture.
+
+## Rounds
+
+1. Intent
+   - Question: Is the priority mobile UX or search/AEO exposure?
+   - Answer: Both, but because this is responsive work, mobile UX is higher priority.
+   - Interpretation: Responsive UI is the first-order objective; SEO/AEO is secondary.
+
+2. Outcome
+   - Question: Which screen best represents success, home or result?
+   - Answer: Result page is more complex and more important.
+   - Interpretation: Result page is the primary success surface.
+
+3. Scope
+   - Question: Should the first pass include only result page or home too?
+   - Answer: First pass should include result screen and home screen.
+   - Interpretation: Both existing screens are in scope; result page remains the priority.
+
+4. Non-goals
+   - Question: What should explicitly stay out of scope?
+   - Answer: No full brand/design renewal, no new UI library, no backend/API change, no blog/landing page additions, and no unrelated requested work. Only make existing screens mobile responsive.
+   - Interpretation: Strict responsive retrofit only.
+
+5. Decision boundary
+   - Question: Should SEO/AEO metadata improvements be included, or only preserved for now?
+   - Answer: Split into first pass; SEO/AEO should be a later separate PR.
+   - Interpretation: First PR is responsive UI only. Existing SEO behavior should not be broken.
+
+6. Success criteria
+   - Question: Is completion satisfied by no horizontal scroll at common widths and natural mobile ordering/usability for home/result pages?
+   - Answer: Yes.
+   - Interpretation: Acceptance should include 375px, 430px, 768px, and desktop checks.
+
+7. Pressure pass
+   - Question: Should mobile result flow reorder around video, lyrics/chords, or chord grid?
+   - Answer: Use the current desktop result screen as the reference.
+   - Interpretation: Preserve existing desktop flow and adapt responsively.
+
+## Readiness Gates
+
+- Non-goals: explicit
+- Decision boundaries: explicit
+- Pressure pass: complete
+
+## Residual Risk
+
+Low. The implementation still needs code-level inspection of the result subcomponents to identify overflow and touch-target issues, but the product scope is clear enough for planning.

--- a/.omx/plans/prd-mobile-responsive-ui-20260519T052151Z.md
+++ b/.omx/plans/prd-mobile-responsive-ui-20260519T052151Z.md
@@ -1,0 +1,186 @@
+# PRD: Mobile Responsive UI First Pass
+
+## Metadata
+
+- Source spec: `.omx/specs/deep-interview-mobile-responsive-seo-aeo.md`
+- Planning mode: ralplan consensus
+- Architect verdict: ITERATE, addressed
+- Critic verdict: APPROVE
+- Scope: existing home and result screens only
+
+## Decision
+
+Implement a narrow first PR that makes the existing ChordLens home and result screens mobile responsive. Use containment and adaptive layout, not redesign. Preserve current desktop result-page flow and defer SEO/AEO implementation to a later PR.
+
+## Principles
+
+1. Containment over redesign: wide music UI should scroll inside its own component, not force viewport overflow.
+2. Preserve desktop reference: desktop flow and geometry should not materially drift.
+3. Keep logic stable: do not refactor playback timing, data fetching, APIs, metadata, or chord rendering internals for this PR.
+4. Mobile usability first: no page-level horizontal scroll, no clipping/overlap, readable content, usable primary touch targets.
+5. Verify the priority surface: result page mobile behavior must be checked with a real route or an explicit fallback.
+
+## Decision Drivers
+
+- Mobile viewport correctness across 375px, 430px, 768px, and desktop.
+- Tight first-PR scope with low regression risk.
+- Result-page usability without changing the product information architecture.
+
+## Alternatives Considered
+
+### A. Internal Containment Plan
+
+Chosen. Make page shells responsive, stack only where fixed-width children break layout, and contain timeline/chord vocabulary overflow inside component scroll areas.
+
+Pros:
+
+- Fits the user's strict first-PR boundary.
+- Avoids playback/data/SEO regressions.
+- Preserves desktop result flow.
+
+Cons:
+
+- Some mobile areas remain horizontally scrollable by design.
+- Requires careful overflow verification.
+
+### B. Mobile-Specific Result Redesign
+
+Rejected. Reordering or redesigning the result experience could improve mobile affordance, but the user explicitly asked to use the current desktop result screen as the reference and avoid redesign.
+
+### C. Bundle SEO/AEO With Responsive PR
+
+Rejected. The user explicitly split SEO/AEO into a later PR. This PR should preserve existing metadata behavior without expanding it.
+
+## In Scope
+
+- `src/views/home/ui/HomePage.tsx`
+- `src/views/result/ui/ResultPage.tsx`
+- `src/entities/chord/ui/LyricsChordPlayer.tsx`
+- `src/entities/chord/ui/ChordGrid.tsx`
+- `src/entities/chord/ui/ChordDiagram.tsx` only if needed for containment, not rendering logic refactor
+- `src/entities/video/ui/VideoCard.tsx` if title/stat wrapping or width containment is needed
+- `src/features/extract-chord/ui/UrlInputForm.tsx`
+- `src/features/list-results/ui/ResultList.tsx`
+- `src/features/list-results/ui/PopularList.tsx` and cards if mobile widths overflow
+- Shared header/footer only if they create scoped page overflow
+
+## Out Of Scope
+
+- Brand or design-system redesign.
+- New UI library or broad dependency changes.
+- Backend/API changes.
+- New pages, blog, landing page, or content strategy.
+- SEO/AEO implementation, structured data, sitemap/robots, canonical/alternate expansion, or broad metadata work.
+- Playback/timing/data-fetching refactors.
+
+## Implementation Plan
+
+1. Establish baseline and result-route verification path.
+   - Confirm current home and result layouts at 375, 430, 768, and desktop.
+   - Find a usable existing result id from local/API state if possible.
+   - If no result route is available, use a temporary uncommitted verification path or document the exact blocker and perform component-level checks.
+
+2. Make the result page shell responsive.
+   - In `ResultPage`, apply responsive padding and gaps such as `px-4 sm:px-6 lg:px-8`, tighter mobile `py/gap`, and `w-full min-w-0` containment around child sections.
+   - Preserve the current vertical order: `VideoCard`, `LyricsChordPlayer`, `ChordGrid`, `ShareButton`.
+
+3. Contain `LyricsChordPlayer`.
+   - Preserve desktop row layout at large breakpoint.
+   - On mobile/tablet, stack the fixed player/control rail above the timeline inside the same card.
+   - Keep `PX_PER_SEC`, `PLAYHEAD_LEFT`, `totalWidth`, scroll/seek/playback logic unchanged.
+   - Ensure timeline overflow stays internal with `min-w-0`, `overflow-hidden`, and an internal `overflow-x-auto` scroll container.
+   - Increase primary play control to at least 44px on mobile.
+   - Verify playhead alignment and scroll seek after stacking.
+
+4. Contain `ChordGrid`.
+   - Use a single mobile strategy: prev/current/next remain in order inside an internal horizontal scroll strip.
+   - Keep fixed `ChordDiagram` size props.
+   - Remove or adapt fixed placeholder widths that force viewport overflow.
+   - Preserve current chord emphasis and desktop centered three-up layout.
+
+5. Make home responsive.
+   - Reduce mobile padding and hero type scale with existing Tailwind utilities.
+   - Keep desktop hero composition materially unchanged; collapse/neutralize the empty right column only where it affects mobile layout.
+   - Ensure URL input, clear button, drag/drop area, and submit button fit mobile widths.
+   - Make recent results responsive, for example `grid-cols-1 sm:grid-cols-2 lg:grid-cols-3`.
+   - Keep popular list horizontally scrollable, reducing mobile auto column width if needed.
+
+6. Apply scoped touch/readability hardening.
+   - Add `min-w-0`, wrapping, line clamps, and responsive spacing where overflow is found.
+   - Preserve focus states and accessibility labels.
+   - Keep primary touch targets at practical mobile sizes, especially playback and form controls.
+
+7. Verify and document.
+   - Run lint/build when dependency state allows.
+   - Inspect home and result route at target widths.
+   - Check `document.documentElement.scrollWidth <= document.documentElement.clientWidth`.
+   - Confirm desktop still matches the existing flow.
+   - Confirm no SEO/AEO implementation was added.
+
+## ADR
+
+### Decision
+
+Use responsive containment for existing home/result screens, with internal horizontal scroll for intrinsically wide music UI.
+
+### Drivers
+
+- Mobile usability is the first priority.
+- Result page is the most complex and important surface.
+- User requested no redesign and no SEO/AEO implementation in this first PR.
+
+### Why Chosen
+
+This approach fixes mobile breakage while minimizing product and technical regression risk. It respects the desktop result page as the source flow and avoids changing playback, chord rendering, data, or metadata behavior.
+
+### Consequences
+
+- Some components, especially timeline and chord vocabulary, may intentionally scroll horizontally inside their own bounds on mobile.
+- Verification must check both page-level overflow and internal scroll usability.
+- SEO/AEO work remains a separate later PR.
+
+### Follow-Ups
+
+- Later SEO/AEO PR: metadata, OpenGraph/Twitter, structured data, canonical/alternate, sitemap/robots, answer-focused copy structure.
+- Optional later mobile UX enhancement: if user wants, revisit whether result page should get a mobile-specific information hierarchy after the containment pass.
+
+## Available Agent Types
+
+- `ralph`: best for sequential implementation with persistent verification.
+- `team`: useful if splitting into independent lanes, such as result page, home page, and verification.
+- `autopilot`: acceptable for a single-agent plan-plus-execute pass, but less explicit about lane ownership.
+
+## Staffing Guidance
+
+### Ralph
+
+Recommended if prioritizing coherence and low regression risk.
+
+Suggested reasoning: `high` for implementation because `LyricsChordPlayer` and `ChordGrid` have fixed layout/math interactions.
+
+Launch hint:
+
+```bash
+$ralph .omx/plans/prd-mobile-responsive-ui-20260519T052151Z.md
+```
+
+### Team
+
+Recommended only if the user wants parallel execution.
+
+Suggested lanes:
+
+- Result lane, high reasoning: `ResultPage`, `LyricsChordPlayer`, `ChordGrid`, `ChordDiagram`.
+- Home lane, medium reasoning: `HomePage`, `UrlInputForm`, `ResultList`, `PopularList`.
+- Verification lane, medium reasoning: dev server, viewport checks, overflow checks, build/lint.
+
+Launch hint:
+
+```bash
+$team .omx/plans/prd-mobile-responsive-ui-20260519T052151Z.md
+```
+
+Team verification path:
+
+- Verification lane must run after integration or against the integrated branch.
+- Any route-level result fallback must be recorded in the final notes.

--- a/.omx/plans/test-spec-mobile-responsive-ui-20260519T052151Z.md
+++ b/.omx/plans/test-spec-mobile-responsive-ui-20260519T052151Z.md
@@ -1,0 +1,74 @@
+# Test Spec: Mobile Responsive UI First Pass
+
+## Scope
+
+Verify the first-pass responsive UI changes for existing home and result pages.
+
+## Static Checks
+
+- `pnpm lint`
+- `pnpm build`
+
+If either cannot run because dependencies or environment are unavailable, record the exact blocker.
+
+## Viewports
+
+Check all scoped pages at:
+
+- 375px phone
+- 430px large phone
+- 768px tablet
+- desktop width, at least 1280px
+
+## Home Page Checks
+
+- Page has no horizontal viewport overflow.
+- Hero heading and supporting text wrap cleanly.
+- URL input, clear button, drag/drop area, and submit button fit within viewport.
+- Popular list remains usable on touch/mobile.
+- Recent results render as 1 column on phone, with appropriate expansion on wider screens.
+- Desktop layout remains materially consistent with the existing design.
+
+## Result Page Checks
+
+- Page has no horizontal viewport overflow.
+- Section order remains `VideoCard`, `LyricsChordPlayer`, `ChordGrid`, `ShareButton`.
+- `VideoCard` title/channel/stats wrap without clipping.
+- `LyricsChordPlayer` stacks on mobile and keeps the timeline scroll internal.
+- Playback button is usable on mobile and remains keyboard/focus accessible.
+- Timeline playhead alignment and scroll/seek behavior are not intentionally changed.
+- `ChordGrid` is usable on mobile through internal horizontal scroll.
+- Current chord remains visually emphasized.
+- Desktop result flow remains materially consistent with the original.
+
+## DOM Overflow Check
+
+For each verified route and viewport:
+
+```js
+document.documentElement.scrollWidth <= document.documentElement.clientWidth;
+```
+
+This should be `true`.
+
+## Scope Guard
+
+Confirm the PR does not include:
+
+- SEO/AEO expansion.
+- New pages.
+- New UI library.
+- Backend/API changes.
+- Playback/timing/data-fetching refactors.
+- Brand/design-system overhaul.
+
+## Result Route Fallback Rule
+
+Because the result page is the priority surface, route-level verification should use a real result page when possible.
+
+If a real result route is unavailable:
+
+1. Try an uncommitted temporary verification path or local data setup.
+2. If still blocked, document the exact blocker.
+3. Perform component-level layout verification as far as possible.
+4. Record clearly whether final verification was route-level or component-level.

--- a/.omx/specs/deep-interview-mobile-responsive-seo-aeo.md
+++ b/.omx/specs/deep-interview-mobile-responsive-seo-aeo.md
@@ -1,0 +1,110 @@
+# Deep Interview Spec: Mobile Responsive UI First Pass
+
+## Metadata
+
+- Slug: mobile-responsive-seo-aeo
+- Profile: standard
+- Context type: brownfield
+- Final ambiguity: 18%
+- Threshold: 20%
+- Context snapshot: `.omx/context/mobile-responsive-seo-aeo-20260519T050442Z.md`
+- Transcript: `.omx/interviews/mobile-responsive-seo-aeo-20260519T051413Z.md`
+
+## Intent
+
+Implement a first-pass mobile responsive UI for existing ChordLens screens. The priority is mobile usability and layout correctness. SEO/AEO matters as a broader product concern, but should be separated into a later PR.
+
+## Desired Outcome
+
+The existing home and result pages should work cleanly across mobile, tablet, and desktop widths. The result page is the most important surface because it contains the complex learning flow: video metadata/player context, lyrics/chords, chord grid, and sharing.
+
+Mobile result layout should use the current desktop result page as the reference flow. Do not invent a new mobile information architecture unless required to prevent overflow or unusable interaction.
+
+## In Scope
+
+- Existing home page responsive improvements.
+- Existing result page responsive improvements.
+- Responsive fixes for components used by those pages when needed, especially:
+  - `VideoCard`
+  - `LyricsChordPlayer`
+  - `ChordGrid`
+  - related chord/lyrics/result list UI that appears on the scoped pages
+- Spacing, layout, wrapping, overflow, touch target, and viewport adaptation fixes.
+- Preserve existing SEO metadata behavior without expanding SEO/AEO implementation.
+- Verify at representative viewport widths: 375px, 430px, 768px, and desktop.
+
+## Out of Scope / Non-goals
+
+- Full brand or design-system redesign.
+- New UI library or broad dependency changes.
+- Backend/API changes.
+- Blog, landing page, or new content surfaces.
+- SEO/AEO implementation as a separate feature, including structured data, sitemap/robots work, canonical/alternate expansion, or broad metadata strategy.
+- Unrequested refactors outside the responsive UI surface.
+
+## Decision Boundaries
+
+OMX may decide:
+
+- Exact responsive breakpoints and Tailwind class adjustments, following existing project conventions.
+- Component-level layout changes necessary to remove overflow and improve mobile usability.
+- Minor spacing and typography adjustments needed for mobile readability.
+- Whether a scoped child component must be adjusted because it causes home/result page overflow.
+
+OMX should not decide without further confirmation:
+
+- Major visual rebranding or wholesale redesign.
+- New libraries or architecture changes.
+- API/data contract changes.
+- New SEO/AEO feature implementation.
+- New pages or content strategy changes.
+
+## Constraints
+
+- Preserve the current tech stack: Next.js, React, Tailwind CSS v4, next-intl.
+- Keep changes tightly scoped to existing screens.
+- Result page should remain aligned with the current desktop flow.
+- Do not degrade existing metadata behavior.
+
+## Acceptance Criteria
+
+- Home page has no horizontal overflow at 375px, 430px, 768px, and desktop widths.
+- Result page has no horizontal overflow at 375px, 430px, 768px, and desktop widths.
+- On mobile, result page content is readable and usable without awkward clipping or layout overlap.
+- On mobile, video/result summary, lyrics/chords, chord grid, and share action follow the current desktop flow in an adapted responsive layout.
+- Touch targets for primary interactions are usable on mobile.
+- Existing desktop layout remains visually coherent after responsive changes.
+- Existing SEO metadata routes still build and behave as before; no SEO/AEO expansion is included in this first PR.
+- Project quality checks pass or any failures are documented with cause.
+
+## Assumptions Exposed + Resolutions
+
+- Assumption: SEO/AEO should be included in the same PR because the initial request mentioned it.
+  - Resolution: False for this first pass. SEO/AEO should be a later PR; responsive UI is the current PR.
+- Assumption: Mobile result layout may need a new priority order.
+  - Resolution: Use the current desktop result page as the reference flow.
+- Assumption: The result page is the key surface.
+  - Resolution: Confirmed; it is more complex and more important than home.
+
+## Pressure-Pass Findings
+
+The pressure pass revisited the result page flow. The user clarified that the mobile result page should reference the current desktop result page rather than prioritizing a new mobile-only order such as moving the chord grid above the lyrics/player flow.
+
+## Brownfield Evidence vs Inference
+
+Evidence:
+
+- `src/views/home/ui/HomePage.tsx` renders the home page and currently uses broad desktop-oriented spacing such as `px-8`, large hero text, and list sections.
+- `src/views/result/ui/ResultPage.tsx` composes `VideoCard`, `LyricsChordPlayer`, `ChordGrid`, and `ShareButton`.
+- `src/app/[locale]/layout.tsx` already defines static metadata.
+- `src/app/[locale]/result/[id]/page.tsx` already defines result-specific metadata.
+
+Inference:
+
+- Responsive issues are likely in page spacing, component overflow, chord/lyrics display, and grid behavior. Implementation should inspect each component before editing.
+
+## Recommended Handoff
+
+Recommended next step: `$ralplan --consensus --direct .omx/specs/deep-interview-mobile-responsive-seo-aeo.md`
+
+Reason: Requirements are now clear enough, but a short implementation plan should inspect actual component structure before editing. Direct execution is also possible if the user wants to skip the planning gate.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,7 +8,7 @@ const eslintConfig = defineConfig([
   ...nextTs,
   // Prettier와 충돌하는 ESLint 규칙 비활성화 (항상 마지막에 위치)
   prettierConfig,
-  globalIgnores([".next/**", "out/**", "build/**", "next-env.d.ts", "node_modules/**"]),
+  globalIgnores([".next/**", ".omx/**", "out/**", "build/**", "next-env.d.ts", "node_modules/**"]),
 ]);
 
 export default eslintConfig;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "next build",
     "start": "next start -p 3000",
     "lint": "eslint .",
+    "test:responsive": "node --test tests/responsive-ui.test.mjs",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/src/entities/chord/ui/ChordDiagram.tsx
+++ b/src/entities/chord/ui/ChordDiagram.tsx
@@ -5,12 +5,13 @@ import { useEffect, useRef } from "react";
 interface Props {
   chordName: string;
   isActive?: boolean;
-  size?: "sm" | "md" | "lg";
+  size?: "xs" | "sm" | "md" | "lg";
   fret?: number;
   voicing?: "open" | "barre";
 }
 
 const SIZES = {
+  xs: { w: 64, h: 76 },
   sm: { w: 120, h: 136 },
   md: { w: 160, h: 180 },
   lg: { w: 190, h: 214 },
@@ -436,6 +437,7 @@ function buildBarreFallback(fret: number): ChordShape {
 export function ChordDiagram({ chordName, isActive = false, size = "md", fret, voicing }: Props) {
   const ref = useRef<HTMLDivElement>(null);
   const { w, h } = SIZES[size];
+  const isCompact = size === "xs";
 
   useEffect(() => {
     if (!ref.current) return;
@@ -532,7 +534,7 @@ export function ChordDiagram({ chordName, isActive = false, size = "md", fret, v
       } catch {
         // vexchords unavailable, render placeholder
         if (ref.current) {
-          ref.current.innerHTML = `<div style="width:160px;height:180px;display:flex;align-items:center;justify-content:center;color:#434654;font-size:12px;">${chordName}</div>`;
+          ref.current.innerHTML = `<div style="width:${w}px;height:${h}px;display:flex;align-items:center;justify-content:center;color:#434654;font-size:12px;">${chordName}</div>`;
         }
       }
     };
@@ -543,7 +545,8 @@ export function ChordDiagram({ chordName, isActive = false, size = "md", fret, v
   return (
     <article
       className={[
-        "flex flex-col rounded-2xl border transition-all duration-200",
+        "flex min-w-0 flex-col border transition-all duration-200",
+        isCompact ? "rounded-xl" : "rounded-2xl",
         isActive
           ? "bg-bg-card border-accent-light/60 shadow-[0_0_24px_rgba(180,197,255,0.15)]"
           : "bg-bg-card border-border/10 hover:border-border/40",
@@ -551,20 +554,38 @@ export function ChordDiagram({ chordName, isActive = false, size = "md", fret, v
       aria-label={`${chordName} 코드 다이어그램`}
     >
       {/* Header */}
-      <div className="flex items-center justify-between px-6 pt-5 pb-2">
+      <div
+        className={[
+          "flex min-w-0 items-center justify-between",
+          isCompact ? "px-2 pt-2 pb-1" : "px-6 pt-5 pb-2",
+        ].join(" ")}
+      >
         <span
           className={[
-            "font-mono text-2xl font-bold",
+            "min-w-0 truncate font-mono font-bold",
+            isCompact ? "text-sm" : "text-2xl",
             isActive ? "text-accent-light" : "text-accent-light",
           ].join(" ")}
         >
           {chordName}
         </span>
-        {isActive && <span className="h-2 w-2 rounded-full bg-accent-light animate-pulse" />}
+        {isActive && (
+          <span
+            className={[
+              "shrink-0 rounded-full bg-accent-light animate-pulse",
+              isCompact ? "h-1.5 w-1.5" : "h-2 w-2",
+            ].join(" ")}
+          />
+        )}
       </div>
 
       {/* Diagram */}
-      <div className="mx-6 rounded-lg bg-bg-dark px-4 py-3 mb-4">
+      <div
+        className={[
+          "bg-bg-dark",
+          isCompact ? "mx-2 mb-2 rounded-md px-1 py-1" : "mx-6 mb-4 rounded-lg px-4 py-3",
+        ].join(" ")}
+      >
         <div ref={ref} />
       </div>
     </article>

--- a/src/entities/chord/ui/ChordGrid.tsx
+++ b/src/entities/chord/ui/ChordGrid.tsx
@@ -12,10 +12,11 @@ export function ChordGrid({ allChords, activeChordIdx }: Props) {
   const next = activeChordIdx < allChords.length - 1 ? allChords[activeChordIdx + 1] : null;
 
   return (
-    <section>
-      <h2 className="font-heading text-xl font-bold text-text-primary mb-6">Vocabulary</h2>
+    <section className="min-w-0">
+      <h2 className="mb-6 font-heading text-xl font-bold text-text-primary">Vocabulary</h2>
 
-      <div className="flex items-center justify-center gap-6">
+      <div className="overflow-x-auto pb-3 [scrollbar-width:thin]">
+        <div className="flex min-w-max items-center justify-start gap-4 px-2 sm:gap-6 md:min-w-0 md:justify-center">
         {/* 이전 코드 */}
         <div className="flex flex-col items-center gap-2 opacity-80 transition-opacity duration-300">
           {prev ? (
@@ -72,6 +73,7 @@ export function ChordGrid({ allChords, activeChordIdx }: Props) {
           ) : (
             <div className="w-[202px] h-[160px]" />
           )}
+        </div>
         </div>
       </div>
     </section>

--- a/src/entities/chord/ui/ChordGrid.tsx
+++ b/src/entities/chord/ui/ChordGrid.tsx
@@ -10,70 +10,105 @@ export function ChordGrid({ allChords, activeChordIdx }: Props) {
   const prev = activeChordIdx > 0 ? allChords[activeChordIdx - 1] : null;
   const current = allChords[activeChordIdx] ?? null;
   const next = activeChordIdx < allChords.length - 1 ? allChords[activeChordIdx + 1] : null;
+  const mobileStartIdx = Math.min(
+    Math.max(activeChordIdx - 1, 0),
+    Math.max(allChords.length - 4, 0),
+  );
+  const mobileChords = allChords.slice(mobileStartIdx, mobileStartIdx + 4);
 
   return (
     <section className="min-w-0">
       <h2 className="mb-6 font-heading text-xl font-bold text-text-primary">Vocabulary</h2>
 
-      <div className="overflow-x-auto pb-3 [scrollbar-width:thin]">
+      <div className="grid grid-cols-4 gap-2 md:hidden">
+        {mobileChords.map((entry, offset) => {
+          const idx = mobileStartIdx + offset;
+          const isActive = idx === activeChordIdx;
+
+          return (
+            <div
+              key={`${entry.time}-${entry.chord}-${idx}`}
+              className="flex min-w-0 flex-col gap-1.5"
+            >
+              <span
+                className={[
+                  "truncate text-center font-mono text-[10px] tabular-nums",
+                  isActive ? "font-bold text-accent-light/80" : "text-text-secondary/60",
+                ].join(" ")}
+              >
+                {entry.time}
+              </span>
+              <ChordDiagram
+                chordName={entry.chord}
+                isActive={isActive}
+                size="xs"
+                fret={entry.fret}
+                voicing={entry.voicing}
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="hidden overflow-x-auto pb-3 [scrollbar-width:thin] md:block">
         <div className="flex min-w-max items-center justify-start gap-4 px-2 sm:gap-6 md:min-w-0 md:justify-center">
-        {/* 이전 코드 */}
-        <div className="flex flex-col items-center gap-2 opacity-80 transition-opacity duration-300">
-          {prev ? (
-            <>
-              <span className="font-mono text-sm text-text-secondary/60 tabular-nums">
-                {prev.time}
-              </span>
-              <ChordDiagram
-                chordName={prev.chord}
-                size="sm"
-                fret={prev.fret}
-                voicing={prev.voicing}
-              />
-            </>
-          ) : (
-            <div className="w-[202px] h-[160px]" />
-          )}
-        </div>
+          {/* 이전 코드 */}
+          <div className="flex flex-col items-center gap-2 opacity-80 transition-opacity duration-300">
+            {prev ? (
+              <>
+                <span className="font-mono text-sm text-text-secondary/60 tabular-nums">
+                  {prev.time}
+                </span>
+                <ChordDiagram
+                  chordName={prev.chord}
+                  size="sm"
+                  fret={prev.fret}
+                  voicing={prev.voicing}
+                />
+              </>
+            ) : (
+              <div className="w-[202px] h-[160px]" />
+            )}
+          </div>
 
-        {/* 현재 코드 (크게, 강조) */}
-        <div className="flex flex-col items-center gap-2 transition-all duration-300 scale-110">
-          {current ? (
-            <>
-              <span className="font-mono text-sm font-bold text-accent-light/70 tabular-nums">
-                {current.time}
-              </span>
-              <ChordDiagram
-                chordName={current.chord}
-                isActive
-                size="lg"
-                fret={current.fret}
-                voicing={current.voicing}
-              />
-            </>
-          ) : (
-            <div className="w-[190px] h-[240px]" />
-          )}
-        </div>
+          {/* 현재 코드 (크게, 강조) */}
+          <div className="flex flex-col items-center gap-2 transition-all duration-300 scale-110">
+            {current ? (
+              <>
+                <span className="font-mono text-sm font-bold text-accent-light/70 tabular-nums">
+                  {current.time}
+                </span>
+                <ChordDiagram
+                  chordName={current.chord}
+                  isActive
+                  size="lg"
+                  fret={current.fret}
+                  voicing={current.voicing}
+                />
+              </>
+            ) : (
+              <div className="w-[190px] h-[240px]" />
+            )}
+          </div>
 
-        {/* 다음 코드 */}
-        <div className="flex flex-col items-center gap-2 opacity-80 transition-opacity duration-300">
-          {next ? (
-            <>
-              <span className="font-mono text-sm text-text-secondary/60 tabular-nums">
-                {next.time}
-              </span>
-              <ChordDiagram
-                chordName={next.chord}
-                size="sm"
-                fret={next.fret}
-                voicing={next.voicing}
-              />
-            </>
-          ) : (
-            <div className="w-[202px] h-[160px]" />
-          )}
-        </div>
+          {/* 다음 코드 */}
+          <div className="flex flex-col items-center gap-2 opacity-80 transition-opacity duration-300">
+            {next ? (
+              <>
+                <span className="font-mono text-sm text-text-secondary/60 tabular-nums">
+                  {next.time}
+                </span>
+                <ChordDiagram
+                  chordName={next.chord}
+                  size="sm"
+                  fret={next.fret}
+                  voicing={next.voicing}
+                />
+              </>
+            ) : (
+              <div className="w-[202px] h-[160px]" />
+            )}
+          </div>
         </div>
       </div>
     </section>

--- a/src/entities/chord/ui/LyricsChordPlayer.tsx
+++ b/src/entities/chord/ui/LyricsChordPlayer.tsx
@@ -167,7 +167,11 @@ export function LyricsChordPlayer({ videoId, lyrics, chords, activeChord, onSele
   // ── 커스텀 재생/일시정지 ─────────────────────────────
   const togglePlay = useCallback(() => {
     if (!playerRef.current) return;
-    isPlaying ? playerRef.current.pauseVideo() : playerRef.current.playVideo();
+    if (isPlaying) {
+      playerRef.current.pauseVideo();
+    } else {
+      playerRef.current.playVideo();
+    }
   }, [isPlaying]);
 
   // ── 수동 스크롤 → seek ──────────────────────────────
@@ -286,7 +290,7 @@ export function LyricsChordPlayer({ videoId, lyrics, chords, activeChord, onSele
           </div>
 
           {/* 오른쪽: 코드 스크롤 타임라인 */}
-          <div className="relative h-[180px] min-w-0 flex-1 overflow-hidden lg:h-auto">
+          <div className="relative h-[180px] min-w-0 shrink-0 overflow-hidden lg:h-auto lg:flex-1">
             {/* Playhead */}
             <div
               className="absolute inset-y-0 z-10 pointer-events-none"

--- a/src/entities/chord/ui/LyricsChordPlayer.tsx
+++ b/src/entities/chord/ui/LyricsChordPlayer.tsx
@@ -205,14 +205,14 @@ export function LyricsChordPlayer({ videoId, lyrics, chords, activeChord, onSele
   const progressPct = duration > 0 ? (currentTime / duration) * 100 : 0;
 
   return (
-    <section className="flex flex-col gap-4">
-      <div className="rounded-2xl bg-bg-dark overflow-hidden">
+    <section className="flex min-w-0 flex-col gap-4">
+      <div className="w-full min-w-0 overflow-hidden rounded-2xl bg-bg-dark">
         {/* ── 가사 표시 ── */}
         {hasLyrics && (
           <>
-            <div className="px-6 pt-5 pb-4 min-h-[68px] flex items-center gap-3">
+            <div className="flex min-h-[68px] min-w-0 items-center gap-3 px-4 pt-5 pb-4 sm:px-6">
               <span className="text-accent-light text-lg select-none">♪</span>
-              <p className="font-heading text-base text-text-primary leading-relaxed flex-1">
+              <p className="min-w-0 flex-1 font-heading text-base leading-relaxed text-text-primary">
                 {currentLyric?.text ?? <span className="text-text-secondary/40">—</span>}
               </p>
               {currentLyric && (
@@ -226,18 +226,18 @@ export function LyricsChordPlayer({ videoId, lyrics, chords, activeChord, onSele
         )}
 
         {/* ── 재생 컨트롤 + 코드 타임라인 ── */}
-        <div className="flex">
+        <div className="flex min-w-0 flex-col lg:flex-row">
           {/* 왼쪽: YouTube 플레이어 + 컨트롤 */}
-          <div className="w-[200px] h-[180px] shrink-0 flex flex-col border-r border-white/5">
+          <div className="flex h-auto w-full shrink-0 flex-col border-b border-white/5 lg:h-[180px] lg:w-[200px] lg:border-r lg:border-b-0">
             {/* YouTube iframe */}
             <div ref={playerDivRef} className="w-full aspect-video bg-black" />
 
             {/* 커스텀 컨트롤 */}
-            <div className="flex items-center gap-2 px-3 py-2 border-t border-white/5">
+            <div className="flex items-center gap-3 border-t border-white/5 px-3 py-2">
               <button
                 onClick={togglePlay}
                 disabled={!playerReady}
-                className="w-8 h-8 rounded-full flex items-center justify-center bg-accent-light/15 border border-accent-light/40 hover:bg-accent-light/25 active:scale-95 transition-all disabled:opacity-30 disabled:cursor-not-allowed shrink-0"
+                className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-accent-light/40 bg-accent-light/15 transition-all hover:bg-accent-light/25 active:scale-95 disabled:cursor-not-allowed disabled:opacity-30 lg:h-8 lg:w-8"
                 aria-label={isPlaying ? "일시정지" : "재생"}
               >
                 {isPlaying ? (
@@ -286,7 +286,7 @@ export function LyricsChordPlayer({ videoId, lyrics, chords, activeChord, onSele
           </div>
 
           {/* 오른쪽: 코드 스크롤 타임라인 */}
-          <div className="flex-1 relative overflow-hidden">
+          <div className="relative h-[180px] min-w-0 flex-1 overflow-hidden lg:h-auto">
             {/* Playhead */}
             <div
               className="absolute inset-y-0 z-10 pointer-events-none"
@@ -305,7 +305,7 @@ export function LyricsChordPlayer({ videoId, lyrics, chords, activeChord, onSele
               onScroll={handleScroll}
               onPointerDown={handlePointerDown}
               onPointerUp={handlePointerUp}
-              className="overflow-x-auto h-full"
+              className="h-full overflow-x-auto"
               style={{
                 scrollbarWidth: "thin",
                 scrollbarColor: "#b4c5ff transparent",

--- a/src/entities/result/ui/ResultListItemCard.tsx
+++ b/src/entities/result/ui/ResultListItemCard.tsx
@@ -10,7 +10,7 @@ export function ResultListItemCard({ item }: ResultListItemCardProps) {
   return (
     <Link
       href={`/result/${item.id}`}
-      className="flex justify-between items-center gap-4 rounded-xl border border-border/10 bg-bg-card/40 px-4 py-3 transition-colors hover:bg-bg-card/70"
+      className="flex min-w-0 items-center justify-between gap-4 rounded-xl border border-border/10 bg-bg-card/40 px-4 py-3 transition-colors hover:bg-bg-card/70"
     >
       {item.thumbnailUrl ? (
         <div className="relative aspect-video basis-1/3 shrink-0 overflow-hidden rounded-xs">
@@ -26,14 +26,14 @@ export function ResultListItemCard({ item }: ResultListItemCardProps) {
         <div className="aspect-video basis-1/3 shrink-0 rounded-xs bg-bg-base/60" />
       )}
 
-      <div className="h-full flex-2 flex flex-col justify-around">
+      <div className="h-full min-w-0 flex-1 flex flex-col justify-around">
         <div className="flex flex-col min-w-0 flex-1">
           <p className="line-clamp-3 font-sans text-sm font-semibold text-text-primary">
             {item.title ? item.title : "제목 없음"}
           </p>
         </div>
 
-        <span className="flex justify-end font-mono text-xs text-text-secondary">
+        <span className="flex justify-end truncate font-mono text-xs text-text-secondary">
           {item.channelName ? item.channelName : "-"}
         </span>
       </div>

--- a/src/entities/video/ui/VideoCard.tsx
+++ b/src/entities/video/ui/VideoCard.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import type { VideoMeta } from "../model/types";
 
 interface Props {

--- a/src/entities/video/ui/VideoCard.tsx
+++ b/src/entities/video/ui/VideoCard.tsx
@@ -8,11 +8,11 @@ interface Props {
 
 export function VideoCard({ meta, onShare }: Props) {
   return (
-    <div className="flex overflow-hidden">
+    <div className="flex min-w-0 overflow-hidden">
       {/* Info */}
-      <div className="flex flex-col justify-between flex-1">
-        <div className="flex items-start justify-between gap-4">
-          <div>
+      <div className="flex min-w-0 flex-1 flex-col justify-between">
+        <div className="flex min-w-0 items-start justify-between gap-4">
+          <div className="min-w-0">
             {/* Badge */}
             <div className="mb-2 inline-flex items-center rounded-full bg-accent-light/10 px-3 py-1">
               <span className="font-heading text-xs font-bold tracking-wide text-accent-light">
@@ -20,12 +20,12 @@ export function VideoCard({ meta, onShare }: Props) {
               </span>
             </div>
             {/* Title */}
-            <h1 className="font-heading text-2xl font-bold leading-tight tracking-tight text-text-primary max-w-lg">
+            <h1 className="max-w-lg font-heading text-xl leading-tight font-bold tracking-tight text-text-primary [overflow-wrap:anywhere] sm:text-2xl">
               {meta.title}
             </h1>
             {/* Channel */}
-            <div className="mt-2 flex items-center gap-2 text-text-secondary">
-              <span className="text-sm">{meta.channelName}</span>
+            <div className="mt-2 flex min-w-0 items-center gap-2 text-text-secondary">
+              <span className="min-w-0 text-sm [overflow-wrap:anywhere]">{meta.channelName}</span>
             </div>
           </div>
 
@@ -57,7 +57,7 @@ export function VideoCard({ meta, onShare }: Props) {
 
         {/* Stats: Tempo + Key */}
         {(meta.tempo || meta.key) && (
-          <div className="mt-4 flex items-center gap-3">
+          <div className="mt-4 flex flex-wrap items-center gap-3">
             {meta.tempo && (
               <div className="flex flex-col rounded-lg bg-bg-input px-4 py-2">
                 <span className="font-sans text-[10px] font-bold uppercase tracking-widest text-text-secondary">

--- a/src/features/extract-chord/ui/UrlInputForm.tsx
+++ b/src/features/extract-chord/ui/UrlInputForm.tsx
@@ -55,11 +55,11 @@ export function UrlInputForm({ onSubmit, isLoading = false }: Props) {
   };
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex min-w-0 flex-col gap-4">
       {/* URL input */}
       <div
         className={[
-          "flex items-center rounded-xl bg-bg-input px-5 h-[63px] transition-all",
+          "flex h-[58px] min-w-0 items-center rounded-xl bg-bg-input px-4 transition-all sm:h-[63px] sm:px-5",
           error ? "ring-1 ring-red-500/50" : "focus-within:ring-1 focus-within:ring-accent/60",
         ].join(" ")}
       >
@@ -76,7 +76,7 @@ export function UrlInputForm({ onSubmit, isLoading = false }: Props) {
           onChange={handleChange}
           onKeyDown={handleKeyDown}
           placeholder={t("YouTube 링크를 붙여넣으세요")}
-          className="flex-1 bg-transparent text-base text-text-primary placeholder-text-secondary/40 outline-none"
+          className="min-w-0 flex-1 bg-transparent text-base text-text-primary placeholder-text-secondary/40 outline-none"
           aria-label={t("YouTube URL 입력")}
           aria-invalid={!!error}
           aria-describedby={error ? "url-error" : undefined}
@@ -123,7 +123,7 @@ export function UrlInputForm({ onSubmit, isLoading = false }: Props) {
         onDrop={handleDrop}
         onClick={() => fileInputRef.current?.click()}
         className={[
-          "flex flex-col items-center justify-center gap-3 rounded-xl border cursor-pointer transition-all h-[130px]",
+          "flex h-[120px] min-w-0 cursor-pointer flex-col items-center justify-center gap-3 rounded-xl border px-4 text-center transition-all sm:h-[130px]",
           isDragging
             ? "border-accent bg-accent/10"
             : "border-border bg-bg-card/30 hover:border-border/70",
@@ -145,7 +145,7 @@ export function UrlInputForm({ onSubmit, isLoading = false }: Props) {
           <circle cx="9" cy="27" r="3" />
           <circle cx="23" cy="24" r="3" />
         </svg>
-        <span className="font-heading text-base text-text-secondary">
+        <span className="font-heading text-sm text-text-secondary sm:text-base">
           {t("MP3 또는 WAV 파일을 여기에 드래그 앤 드롭하세요")}
         </span>
       </div>
@@ -161,7 +161,7 @@ export function UrlInputForm({ onSubmit, isLoading = false }: Props) {
       <Button
         type="button"
         variant="gradient"
-        className="h-[68px] w-full text-lg gap-3"
+        className="h-14 w-full gap-3 text-base sm:h-[68px] sm:text-lg"
         onClick={handleSubmit}
         disabled={!isValid}
         loading={isLoading}

--- a/src/features/list-results/ui/PopularAlbumCard.tsx
+++ b/src/features/list-results/ui/PopularAlbumCard.tsx
@@ -11,7 +11,7 @@ export function PopularAlbumCard({ item }: PopularAlbumCardProps) {
   const formattedDuration = formatDuration(item.duration);
 
   return (
-    <Link href={`/result/${item.id}`} className="group flex flex-col gap-2">
+    <Link href={`/result/${item.id}`} className="group flex min-w-0 flex-col gap-2">
       <div className="relative aspect-square w-full overflow-hidden rounded-lg bg-bg-card/60">
         {item.thumbnailUrl ? (
           <Image
@@ -34,7 +34,9 @@ export function PopularAlbumCard({ item }: PopularAlbumCardProps) {
         <p className="line-clamp-2 font-sans text-sm font-semibold text-text-primary">
           {item.title ?? "제목 없음"}
         </p>
-        <span className="font-sans text-xs text-text-secondary">{item.channelName ?? "-"}</span>
+        <span className="truncate font-sans text-xs text-text-secondary">
+          {item.channelName ?? "-"}
+        </span>
       </div>
     </Link>
   );

--- a/src/features/list-results/ui/PopularList.tsx
+++ b/src/features/list-results/ui/PopularList.tsx
@@ -36,7 +36,7 @@ export function PopularList() {
 
   if (isPending) {
     return (
-      <div className="grid grid-flow-col grid-rows-[repeat(2,auto)] auto-cols-[14rem] gap-4 overflow-hidden">
+      <div className="grid grid-flow-col grid-rows-[repeat(2,auto)] auto-cols-[11rem] gap-4 overflow-hidden sm:auto-cols-[14rem]">
         {Array.from({ length: 8 }).map((_, i) => (
           <div key={i} className="flex flex-col gap-2">
             <div className="aspect-square w-full animate-pulse rounded-lg bg-bg-card/40" />
@@ -71,7 +71,7 @@ export function PopularList() {
       <div
         ref={scrollRef}
         onScroll={syncScrollState}
-        className="grid grid-flow-col grid-rows-[repeat(2,auto)] auto-cols-[14rem] gap-4 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+        className="grid grid-flow-col grid-rows-[repeat(2,auto)] auto-cols-[11rem] gap-4 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] sm:auto-cols-[14rem] [&::-webkit-scrollbar]:hidden"
       >
         {data.items.map((item) => (
           <PopularAlbumCard key={item.id} item={item} />

--- a/src/features/list-results/ui/ResultList.tsx
+++ b/src/features/list-results/ui/ResultList.tsx
@@ -43,7 +43,7 @@ export function ResultList() {
   }
 
   return (
-    <div className="grid grid-cols-3 gap-2">
+    <div className="grid min-w-0 grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
       {data.items.map((item) => (
         <ResultListItemCard key={item.id} item={item} />
       ))}

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -27,6 +27,7 @@ export function Button({
 
   return (
     <button
+      type={type}
       className={`${base} ${variants[variant]} ${className}`}
       disabled={disabled || loading}
       {...props}

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -17,40 +17,40 @@ export function HomePage() {
   );
 
   return (
-    <main className="min-h-screen">
+    <main className="min-h-screen overflow-x-clip">
       {/* ─── Hero & Input Section ─── */}
-      <section className="mx-auto max-w-7xl px-8 pt-12 pb-10">
-        <div className="flex flex-col lg:flex-row gap-12 items-start">
-          <div className="flex-1 max-w-2xl">
-            <h1 className="font-heading text-5xl lg:text-[60px] font-bold leading-[1.2] tracking-[-0.025em] text-text-primary mb-6">
+      <section className="mx-auto w-full max-w-7xl px-4 pt-8 pb-8 sm:px-6 sm:pt-10 lg:px-8 lg:pt-12 lg:pb-10">
+        <div className="flex min-w-0 flex-col items-start gap-8 lg:flex-row lg:gap-12">
+          <div className="w-full min-w-0 max-w-2xl flex-1">
+            <h1 className="mb-5 font-heading text-4xl leading-[1.15] font-bold tracking-[-0.025em] text-text-primary sm:text-5xl sm:leading-[1.2] lg:mb-6 lg:text-[60px]">
               {t("YouTube 동영상에서")}{" "}
               <span className="bg-linear-to-r from-accent-light to-accent bg-clip-text text-transparent">
                 {t("기타 코드를 배우세요")}
               </span>
             </h1>
-            <p className="font-sans text-lg text-text-secondary leading-relaxed mb-8 max-w-xl">
+            <p className="mb-6 max-w-xl font-sans text-base leading-relaxed text-text-secondary sm:mb-8 sm:text-lg">
               {t("좋아하는 곡의 링크를 붙여보세요")}
             </p>
 
             <UrlInputForm onSubmit={handleSubmit} isLoading={mutation.isPending} />
           </div>
 
-          <div className=""></div>
+          <div className="hidden lg:block"></div>
         </div>
       </section>
 
       {/* ─── Loading State ─── */}
       {mutation.isPending && mutation.pipelineStatus !== "idle" && (
-        <section className="mx-auto max-w-7xl px-8 pb-8">
+        <section className="mx-auto w-full max-w-7xl px-4 pb-8 sm:px-6 lg:px-8">
           <LoadingState status={mutation.pipelineStatus} progress={mutation.progress} />
         </section>
       )}
 
       {/* ─── Error State ─── */}
       {mutation.isError && (
-        <section className="mx-auto max-w-7xl px-8 pb-8">
-          <div className="rounded-2xl bg-red-900/20 border border-red-500/20 px-8 py-6 flex items-center justify-between">
-            <div>
+        <section className="mx-auto w-full max-w-7xl px-4 pb-8 sm:px-6 lg:px-8">
+          <div className="flex flex-col gap-4 rounded-2xl border border-red-500/20 bg-red-900/20 px-5 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-8 sm:py-6">
+            <div className="min-w-0">
               <p className="font-heading font-bold text-red-300">{t("분석 실패")}</p>
               <p className="font-sans text-sm text-red-400 mt-1">
                 {mutation.error?.message ?? t("알 수 없는 오류가 발생했습니다")}
@@ -58,7 +58,7 @@ export function HomePage() {
             </div>
             <button
               onClick={() => mutation.reset()}
-              className="font-sans text-sm font-semibold text-red-300 hover:text-red-200 underline"
+              className="self-start font-sans text-sm font-semibold text-red-300 underline hover:text-red-200 sm:self-auto"
             >
               {t("다시 시도")}
             </button>
@@ -66,14 +66,14 @@ export function HomePage() {
         </section>
       )}
 
-      <section className="mx-auto max-w-7xl px-8 pb-8">
+      <section className="mx-auto w-full max-w-7xl px-4 pb-8 sm:px-6 lg:px-8">
         <p className="font-mono text-xs tracking-widest text-text-secondary uppercase mb-4">
           {t("인기")}
         </p>
         <PopularList />
       </section>
 
-      <section className="mx-auto max-w-7xl px-8 pb-16">
+      <section className="mx-auto w-full max-w-7xl px-4 pb-14 sm:px-6 lg:px-8 lg:pb-16">
         <p className="font-mono text-xs tracking-widest text-text-secondary uppercase mb-4">
           {t("최근")}
         </p>

--- a/src/views/result/ui/ResultPage.tsx
+++ b/src/views/result/ui/ResultPage.tsx
@@ -20,7 +20,7 @@ export function ResultPage({ result }: Props) {
   }, []);
 
   return (
-    <main className="mx-auto max-w-7xl px-8 py-10 flex flex-col gap-8">
+    <main className="mx-auto flex w-full max-w-7xl min-w-0 flex-col gap-6 overflow-x-clip px-4 py-6 sm:px-6 sm:py-8 lg:gap-8 lg:px-8 lg:py-10">
       <VideoCard
         meta={{
           title: result.title,

--- a/tests/responsive-ui.test.mjs
+++ b/tests/responsive-ui.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const read = (path) => readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("home page uses responsive containment for mobile-first sections", () => {
+  const home = read("src/views/home/ui/HomePage.tsx");
+
+  assert.match(home, /overflow-x-clip/);
+  assert.match(home, /px-4/);
+  assert.match(home, /sm:px-6/);
+  assert.match(home, /lg:px-8/);
+  assert.match(home, /text-4xl/);
+});
+
+test("result page preserves section order and contains wide children", () => {
+  const result = read("src/views/result/ui/ResultPage.tsx");
+  const order = [
+    result.indexOf("<VideoCard"),
+    result.indexOf("<LyricsChordPlayer"),
+    result.indexOf("<ChordGrid"),
+    result.indexOf("<ShareButton"),
+  ];
+
+  assert.ok(order.every((index) => index >= 0), "expected all result sections to be present");
+  assert.deepEqual(
+    [...order].sort((a, b) => a - b),
+    order,
+    "result section order must remain VideoCard, LyricsChordPlayer, ChordGrid, ShareButton",
+  );
+  assert.match(result, /min-w-0/);
+  assert.match(result, /overflow-x-clip/);
+});
+
+test("lyrics chord player stacks controls on mobile with internal timeline scrolling", () => {
+  const player = read("src/entities/chord/ui/LyricsChordPlayer.tsx");
+
+  assert.match(player, /flex-col lg:flex-row/);
+  assert.match(player, /h-\[180px\] min-w-0 flex-1 overflow-hidden/);
+  assert.match(player, /h-full overflow-x-auto/);
+  assert.match(player, /h-11 w-11/);
+});
+
+test("chord grid and result lists use responsive/internal overflow strategies", () => {
+  const chordGrid = read("src/entities/chord/ui/ChordGrid.tsx");
+  const resultList = read("src/features/list-results/ui/ResultList.tsx");
+  const popularList = read("src/features/list-results/ui/PopularList.tsx");
+
+  assert.match(chordGrid, /overflow-x-auto/);
+  assert.match(chordGrid, /min-w-max/);
+  assert.match(resultList, /grid-cols-1/);
+  assert.match(resultList, /sm:grid-cols-2/);
+  assert.match(resultList, /lg:grid-cols-3/);
+  assert.match(popularList, /auto-cols-\[11rem\]/);
+});
+
+test("scope guard: responsive pass does not add SEO or backend API expansion", () => {
+  const touchedUi = [
+    "src/views/home/ui/HomePage.tsx",
+    "src/views/result/ui/ResultPage.tsx",
+    "src/entities/chord/ui/LyricsChordPlayer.tsx",
+    "src/entities/chord/ui/ChordGrid.tsx",
+    "src/entities/video/ui/VideoCard.tsx",
+    "src/features/extract-chord/ui/UrlInputForm.tsx",
+    "src/features/list-results/ui/ResultList.tsx",
+    "src/entities/result/ui/ResultListItemCard.tsx",
+    "src/features/list-results/ui/PopularList.tsx",
+    "src/features/list-results/ui/PopularAlbumCard.tsx",
+  ]
+    .map(read)
+    .join("\n");
+
+  assert.doesNotMatch(touchedUi, /structuredData|jsonLd|canonical|sitemap|robots/i);
+  assert.doesNotMatch(touchedUi, /NextResponse|export async function (GET|POST|PUT|DELETE)/);
+});

--- a/tests/responsive-ui.test.mjs
+++ b/tests/responsive-ui.test.mjs
@@ -37,7 +37,11 @@ test("lyrics chord player stacks controls on mobile with internal timeline scrol
   const player = read("src/entities/chord/ui/LyricsChordPlayer.tsx");
 
   assert.match(player, /flex-col lg:flex-row/);
-  assert.match(player, /h-\[180px\] min-w-0 flex-1 overflow-hidden/);
+  assert.match(player, /h-\[180px\]/);
+  assert.match(player, /min-w-0/);
+  assert.match(player, /shrink-0/);
+  assert.match(player, /overflow-hidden/);
+  assert.match(player, /lg:flex-1/);
   assert.match(player, /h-full overflow-x-auto/);
   assert.match(player, /h-11 w-11/);
 });


### PR DESCRIPTION
## Summary
- 홈/결과 화면의 모바일-first spacing과 containment를 조정했습니다.
- 결과 화면의 영상 카드, 가사/코드 플레이어, 코드 그리드가 좁은 viewport에서 page-level 가로 overflow를 만들지 않도록 정리했습니다.
- 반응형 회귀 방지 테스트를 추가하고 현재 타임라인 레이아웃 조건에 맞게 보정했습니다.

## Test Plan
- [x] pnpm test:responsive
- [x] pnpm lint
- [x] pnpm build

closes #16