### PR TITLE
feat: #18 홈 초기 로드 최적화(서버 prefetch로 데이터 워터폴 제거)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ next-env.d.ts
 
 # OMX runtime state
 .omx/
+
+# 개인 학습 노트
+study/

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,5 +1,41 @@
+import { cache } from "react";
+import { headers } from "next/headers";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { getQueryClient } from "@/shared/lib/getQueryClient";
+import {
+  getResults,
+  getPopularResults,
+  resultsQueryKey,
+  popularResultsQueryKey,
+} from "@/entities/result";
 import { HomePage } from "@/views/home";
 
-export default function Home() {
-  return <HomePage />;
+const getBaseUrl = cache(async (): Promise<string> => {
+  const h = await headers();
+  const host = h.get("host") ?? "localhost:3000";
+  return `${host.startsWith("localhost") ? "http" : "https"}://${host}`;
+});
+
+export default async function Home() {
+  const queryClient = getQueryClient();
+  const baseUrl = await getBaseUrl();
+
+  // 실패 허용: prefetchQuery reject가 allSettled로 page render를 reject하지 않음.
+  // v5 기본 dehydrate는 에러 쿼리를 redact → 정상 응답만 첫 HTML에 동봉(워터폴 제거).
+  await Promise.allSettled([
+    queryClient.prefetchQuery({
+      queryKey: popularResultsQueryKey,
+      queryFn: () => getPopularResults(baseUrl),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: resultsQueryKey,
+      queryFn: () => getResults(baseUrl),
+    }),
+  ]);
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <HomePage />
+    </HydrationBoundary>
+  );
 }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,22 +1,12 @@
 "use client";
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { ThemeProvider } from "next-themes";
 import { useState } from "react";
+import { getQueryClient } from "@/shared/lib/getQueryClient";
 
 export function Providers({ children }: { children: React.ReactNode }) {
-  const [queryClient] = useState(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          queries: {
-            staleTime: Infinity,
-            gcTime: 1000 * 60 * 10,
-            retry: 1,
-          },
-        },
-      }),
-  );
+  const [queryClient] = useState(() => getQueryClient());
 
   return (
     <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>

--- a/src/entities/result/api/getPopularResults.ts
+++ b/src/entities/result/api/getPopularResults.ts
@@ -1,7 +1,8 @@
 import type { ResultListResponse } from "../model/types";
 
-export async function getPopularResults(): Promise<ResultListResponse> {
-  const res = await fetch("/api/results/popular");
+export async function getPopularResults(baseUrl = ""): Promise<ResultListResponse> {
+  // baseUrl 빈 값=브라우저 상대 URL, 절대 URL=서버 RSC prefetch. cache:"no-store"는 precedent getResultById와 일치.
+  const res = await fetch(`${baseUrl}/api/results/popular`, { cache: "no-store" });
   if (!res.ok) return { items: [], total: 0 };
   return res.json() as Promise<ResultListResponse>;
 }

--- a/src/entities/result/api/getResults.ts
+++ b/src/entities/result/api/getResults.ts
@@ -1,7 +1,7 @@
 import type { ResultListResponse } from "../model/types";
 
-export async function getResults(): Promise<ResultListResponse> {
-  const res = await fetch("/api/results");
+export async function getResults(baseUrl = ""): Promise<ResultListResponse> {
+  const res = await fetch(`${baseUrl}/api/results`, { cache: "no-store" });
 
   if (res.status === 504) {
     throw new Error("요청 시간이 초과되었습니다.");

--- a/src/entities/result/index.ts
+++ b/src/entities/result/index.ts
@@ -1,5 +1,5 @@
 export type { ResultListItem, ResultListResponse } from "./model/types";
-export { resultsQueryKey } from "./model/queryKeys";
+export { resultsQueryKey, popularResultsQueryKey } from "./model/queryKeys";
 export { getResults } from "./api/getResults";
 export { getResultById } from "./api/getResultById";
 export { getPopularResults } from "./api/getPopularResults";

--- a/src/entities/result/model/queryKeys.ts
+++ b/src/entities/result/model/queryKeys.ts
@@ -1,1 +1,2 @@
 export const resultsQueryKey = ["results"] as const;
+export const popularResultsQueryKey = ["results", "popular"] as const;

--- a/src/features/list-results/api/usePopularResults.ts
+++ b/src/features/list-results/api/usePopularResults.ts
@@ -1,15 +1,12 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { getPopularResults } from "@/entities/result";
+import { getPopularResults, popularResultsQueryKey } from "@/entities/result";
 import type { ResultListResponse } from "@/entities/result";
-
-export const popularResultsQueryKey = ["results", "popular"] as const;
 
 export function usePopularResults() {
   return useQuery<ResultListResponse>({
     queryKey: popularResultsQueryKey,
-    queryFn: getPopularResults,
-    refetchOnMount: "always",
+    queryFn: () => getPopularResults(),
   });
 }

--- a/src/features/list-results/api/useResults.ts
+++ b/src/features/list-results/api/useResults.ts
@@ -4,12 +4,9 @@ import { useQuery } from "@tanstack/react-query";
 import { getResults, resultsQueryKey } from "@/entities/result";
 import type { ResultListResponse } from "@/entities/result";
 
-export { resultsQueryKey } from "@/entities/result";
-
 export function useResults() {
   return useQuery<ResultListResponse>({
     queryKey: resultsQueryKey,
-    queryFn: getResults,
-    refetchOnMount: "always",
+    queryFn: () => getResults(),
   });
 }

--- a/src/features/list-results/index.ts
+++ b/src/features/list-results/index.ts
@@ -1,4 +1,5 @@
 export { ResultList } from "./ui/ResultList";
 export { PopularList } from "./ui/PopularList";
-export { useResults, resultsQueryKey } from "./api/useResults";
-export { usePopularResults, popularResultsQueryKey } from "./api/usePopularResults";
+export { useResults } from "./api/useResults";
+export { usePopularResults } from "./api/usePopularResults";
+export { resultsQueryKey, popularResultsQueryKey } from "@/entities/result";

--- a/src/shared/lib/getQueryClient.ts
+++ b/src/shared/lib/getQueryClient.ts
@@ -1,0 +1,23 @@
+import { QueryClient, isServer } from "@tanstack/react-query";
+
+function makeQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: Infinity,
+        gcTime: 1000 * 60 * 10,
+        retry: 1,
+      },
+    },
+  });
+}
+
+let browserQueryClient: QueryClient | undefined;
+
+export function getQueryClient(): QueryClient {
+  // 서버: 매 요청 새 인스턴스(요청 간 캐시 오염 방지).
+  if (isServer) return makeQueryClient();
+  // 브라우저: 싱글턴 재사용.
+  if (!browserQueryClient) browserQueryClient = makeQueryClient();
+  return browserQueryClient;
+}

--- a/src/views/home/index.ts
+++ b/src/views/home/index.ts
@@ -1,1 +1,5 @@
 export { HomePage } from "./ui/HomePage";
+export { HomeHero } from "./ui/HomeHero";
+export { ExtractSection } from "./ui/ExtractSection";
+export { PopularSection } from "./ui/PopularSection";
+export { RecentSection } from "./ui/RecentSection";

--- a/src/views/home/ui/ExtractSection.tsx
+++ b/src/views/home/ui/ExtractSection.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useCallback } from "react";
+import { useTranslations } from "next-intl";
+import { useExtractChord, UrlInputForm, LoadingState } from "@/features/extract-chord";
+
+interface ExtractSectionProps {
+  /** 서버에서 렌더되는 배경(client child)·정적 히어로 카피(h1/p). RSC children으로 전달. */
+  background: React.ReactNode;
+  heroCopy: React.ReactNode;
+}
+
+export function ExtractSection({ background, heroCopy }: ExtractSectionProps): React.JSX.Element {
+  const t = useTranslations();
+  const mutation = useExtractChord();
+
+  const handleSubmit = useCallback(
+    (url: string) => {
+      mutation.mutate(url);
+    },
+    [mutation],
+  );
+
+  return (
+    <>
+      {/* ─── Hero & Input Section ─── */}
+      <section className="relative isolate mx-auto w-full max-w-7xl flex justify-center items-center overflow-hidden px-4 pt-8 pb-8 sm:px-6 sm:pt-10 lg:px-8 lg:pt-12 lg:pb-10">
+        {background}
+        <div className="flex min-w-0 flex-col items-start gap-8">
+          <div className="w-full min-w-0 max-w-2xl">
+            {heroCopy}
+            <UrlInputForm onSubmit={handleSubmit} isLoading={mutation.isPending} />
+          </div>
+        </div>
+      </section>
+
+      {/* ─── Loading State ─── */}
+      {mutation.isPending && mutation.pipelineStatus !== "idle" && (
+        <section className="mx-auto w-full max-w-7xl px-4 pb-8 sm:px-6 lg:px-8">
+          <LoadingState status={mutation.pipelineStatus} progress={mutation.progress} />
+        </section>
+      )}
+
+      {/* ─── Error State ─── */}
+      {mutation.isError && (
+        <section className="mx-auto w-full max-w-7xl px-4 pb-8 sm:px-6 lg:px-8">
+          <div className="flex flex-col gap-4 rounded-2xl border border-red-500/20 bg-red-900/20 px-5 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-8 sm:py-6">
+            <div className="min-w-0">
+              <p className="font-heading font-bold text-red-300">{t("분석 실패")}</p>
+              <p className="font-sans text-sm text-red-400 mt-1">
+                {mutation.error?.message ?? t("알 수 없는 오류가 발생했습니다")}
+              </p>
+            </div>
+            <button
+              onClick={() => mutation.reset()}
+              className="self-start font-sans text-sm font-semibold text-red-300 underline hover:text-red-200 sm:self-auto"
+            >
+              {t("다시 시도")}
+            </button>
+          </div>
+        </section>
+      )}
+    </>
+  );
+}

--- a/src/views/home/ui/HomeHero.tsx
+++ b/src/views/home/ui/HomeHero.tsx
@@ -1,0 +1,26 @@
+import { getTranslations } from "next-intl/server";
+import { BackgroundPaths } from "@/shared/ui/BackgroundPaths";
+import { ExtractSection } from "./ExtractSection";
+
+export async function HomeHero(): Promise<React.JSX.Element> {
+  const t = await getTranslations();
+
+  return (
+    <ExtractSection
+      background={<BackgroundPaths className="absolute inset-0 -z-10" />}
+      heroCopy={
+        <>
+          <h1 className="mb-5 font-heading text-4xl leading-[1.15] font-bold tracking-[-0.025em] text-text-primary sm:text-5xl sm:leading-[1.2] lg:mb-6 lg:text-[60px]">
+            {t("YouTube 동영상에서")}
+            <div className="bg-linear-to-r from-accent-light to-accent bg-clip-text text-transparent">
+              {t("기타 코드를 배우세요")}
+            </div>
+          </h1>
+          <p className="mb-6 max-w-xl font-sans text-base leading-relaxed text-text-secondary sm:mb-8 sm:text-lg">
+            {t("좋아하는 곡의 링크를 붙여보세요")}
+          </p>
+        </>
+      }
+    />
+  );
+}

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -1,84 +1,13 @@
-"use client";
+import { HomeHero } from "./HomeHero";
+import { PopularSection } from "./PopularSection";
+import { RecentSection } from "./RecentSection";
 
-import { useCallback } from "react";
-import { useTranslations } from "next-intl";
-import { useExtractChord, UrlInputForm, LoadingState } from "@/features/extract-chord";
-import { PopularList, ResultList } from "@/features/list-results";
-import { BackgroundPaths } from "@/shared/ui/BackgroundPaths";
-
-export function HomePage() {
-  const t = useTranslations();
-  const mutation = useExtractChord();
-
-  const handleSubmit = useCallback(
-    (url: string) => {
-      mutation.mutate(url);
-    },
-    [mutation],
-  );
-
+export function HomePage(): React.JSX.Element {
   return (
     <main className="min-h-screen overflow-x-clip">
-      {/* ─── Hero & Input Section ─── */}
-      <section className="relative isolate mx-auto w-full max-w-7xl flex justify-center items-center overflow-hidden px-4 pt-8 pb-8 sm:px-6 sm:pt-10 lg:px-8 lg:pt-12 lg:pb-10">
-        <BackgroundPaths className="absolute inset-0 -z-10" />
-        <div className="flex min-w-0 flex-col items-start gap-8">
-          <div className="w-full min-w-0 max-w-2xl">
-            <h1 className="mb-5 font-heading text-4xl leading-[1.15] font-bold tracking-[-0.025em] text-text-primary sm:text-5xl sm:leading-[1.2] lg:mb-6 lg:text-[60px]">
-              {t("YouTube 동영상에서")}
-              <div className="bg-linear-to-r from-accent-light to-accent bg-clip-text text-transparent">
-                {t("기타 코드를 배우세요")}
-              </div>
-            </h1>
-            <p className="mb-6 max-w-xl font-sans text-base leading-relaxed text-text-secondary sm:mb-8 sm:text-lg">
-              {t("좋아하는 곡의 링크를 붙여보세요")}
-            </p>
-
-            <UrlInputForm onSubmit={handleSubmit} isLoading={mutation.isPending} />
-          </div>
-        </div>
-      </section>
-
-      {/* ─── Loading State ─── */}
-      {mutation.isPending && mutation.pipelineStatus !== "idle" && (
-        <section className="mx-auto w-full max-w-7xl px-4 pb-8 sm:px-6 lg:px-8">
-          <LoadingState status={mutation.pipelineStatus} progress={mutation.progress} />
-        </section>
-      )}
-
-      {/* ─── Error State ─── */}
-      {mutation.isError && (
-        <section className="mx-auto w-full max-w-7xl px-4 pb-8 sm:px-6 lg:px-8">
-          <div className="flex flex-col gap-4 rounded-2xl border border-red-500/20 bg-red-900/20 px-5 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-8 sm:py-6">
-            <div className="min-w-0">
-              <p className="font-heading font-bold text-red-300">{t("분석 실패")}</p>
-              <p className="font-sans text-sm text-red-400 mt-1">
-                {mutation.error?.message ?? t("알 수 없는 오류가 발생했습니다")}
-              </p>
-            </div>
-            <button
-              onClick={() => mutation.reset()}
-              className="self-start font-sans text-sm font-semibold text-red-300 underline hover:text-red-200 sm:self-auto"
-            >
-              {t("다시 시도")}
-            </button>
-          </div>
-        </section>
-      )}
-
-      <section className="mx-auto w-full max-w-7xl px-4 pb-8 sm:px-6 lg:px-8">
-        <p className="font-mono text-xs tracking-widest text-text-secondary uppercase mb-4">
-          {t("인기")}
-        </p>
-        <PopularList />
-      </section>
-
-      <section className="mx-auto w-full max-w-7xl px-4 pb-14 sm:px-6 lg:px-8 lg:pb-16">
-        <p className="font-mono text-xs tracking-widest text-text-secondary uppercase mb-4">
-          {t("최근")}
-        </p>
-        <ResultList />
-      </section>
+      <HomeHero />
+      <PopularSection />
+      <RecentSection />
     </main>
   );
 }

--- a/src/views/home/ui/PopularSection.tsx
+++ b/src/views/home/ui/PopularSection.tsx
@@ -1,0 +1,15 @@
+import { getTranslations } from "next-intl/server";
+import { PopularList } from "@/features/list-results";
+
+export async function PopularSection(): Promise<React.JSX.Element> {
+  const t = await getTranslations();
+
+  return (
+    <section className="mx-auto w-full max-w-7xl px-4 pb-8 sm:px-6 lg:px-8">
+      <p className="font-mono text-xs tracking-widest text-text-secondary uppercase mb-4">
+        {t("인기")}
+      </p>
+      <PopularList />
+    </section>
+  );
+}

--- a/src/views/home/ui/RecentSection.tsx
+++ b/src/views/home/ui/RecentSection.tsx
@@ -1,0 +1,15 @@
+import { getTranslations } from "next-intl/server";
+import { ResultList } from "@/features/list-results";
+
+export async function RecentSection(): Promise<React.JSX.Element> {
+  const t = await getTranslations();
+
+  return (
+    <section className="mx-auto w-full max-w-7xl px-4 pb-14 sm:px-6 lg:px-8 lg:pb-16">
+      <p className="font-mono text-xs tracking-widest text-text-secondary uppercase mb-4">
+        {t("최근")}
+      </p>
+      <ResultList />
+    </section>
+  );
+}


### PR DESCRIPTION
## 관련 Issue

closes #18

## 변경 내용

홈 화면의 클라이언트 데이터 워터폴을 제거하고 초기 로드 성능을 개선했다.
서버에서 인기/최근 결과를 prefetch 후 dehydrate하여 HydrationBoundary로 전달함으로써, 클라이언트 마운트 후 발생하던 추가 페칭 워터폴을 제거했다. 또한 홈 히어로를 RSC로 분리하고 인터랙션 영역만 클라이언트 컴포넌트로 유지했다.

의도된 트레이드오프:
- 정상 응답 시 클라이언트 데이터 워터폴 제거로 초기 콘텐츠 표시를 앞당김
- 서버 prefetch에서 `headers()` 사용으로 해당 라우트는 dynamic SSR로 동작 (요청 시 렌더)

## 작업 내용

- [x] 서버 prefetch/dehydrate + HydrationBoundary 적용 (page.tsx)
- [x] 홈 히어로 RSC 분리 (HomeHero) + 인터랙션 영역 클라이언트 분리 (ExtractSection)
- [x] PopularSection / RecentSection 분리하여 hydrate된 데이터 사용
- [x] React Query `refetchOnMount` 정합화
- [x] 공용 서버 QueryClient 유틸(getQueryClient) 추가 및 providers 정리

## 체크리스트

- [x] 타입 오류 없음
- [x] 불필요한 console.log 제거
- [x] 관련 Issue 연결됨

## 참고

영향 범위: FE 전용. QA 통과 (`_workspace/05_qa_report.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)